### PR TITLE
feat: add DeepL provider (experimental)

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,9 +1,11 @@
 {
   "runtime": {
-    "version": "LuaJIT"
+    "version": "LuaJIT",
+    "pathStrict": true
   },
   "diagnostics": {
-    "globals": ["vim"]
+    "globals": ["vim"],
+    "disable": ["missing-fields"]
   },
   "workspace": {
     "library": [
@@ -11,5 +13,18 @@
       "${3rd}/luv/library"
     ],
     "checkThirdParty": false
+  },
+  "hint": {
+    "enable": true,
+    "setType": true,
+    "paramName": "All",
+    "paramType": true,
+    "arrayIndex": "Enable"
+  },
+  "completion": {
+    "callSnippet": "Replace"
+  },
+  "type": {
+    "castNumberToInteger": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- DeepL provider with API key support (config or `DEEPL_API_KEY` env) — **🧪 experimental, may not work as expected**
+- Auto-detect DeepL Free/Pro endpoint by key suffix (`:fx`)
+- DeepL formality option (`default`, `more`, `less`, `prefer_more`, `prefer_less`)
+- Automatic fallback to Google Translate when DeepL API key is missing
+
 ## [0.1.0] - 2025-12-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - `curl`
 
 **Optional** (for picker display):
+
 - snacks.nvim, telescope.nvim, fzf-lua, or mini.pick
 
 ## 📦 Installation
@@ -77,7 +78,7 @@ require("babel").setup({
 require("babel").setup({
   source = "auto",        -- source language (auto-detect)
   target = "ru",          -- target language
-  provider = "google",    -- translation provider
+  provider = "google",    -- translation provider: "google", "deepl"
   display = "float",      -- "float" or "picker"
   picker = "auto",        -- "auto", "telescope", "fzf", "snacks", "mini"
   float = {
@@ -88,6 +89,12 @@ require("babel").setup({
   keymaps = {
     translate = "<leader>tr",
     translate_word = "<leader>tw",
+  },
+  -- DeepL provider settings (optional)
+  deepl = {
+    api_key = nil,        -- or use DEEPL_API_KEY env variable
+    pro = nil,            -- nil = auto-detect, true = Pro, false = Free
+    formality = "default", -- "default", "more", "less", "prefer_more", "prefer_less"
   },
 })
 ```
@@ -100,9 +107,12 @@ require("babel").setup({
 |--------|------|---------|-------------|
 | `source` | string | `"auto"` | Source language (auto-detect) |
 | `target` | string | `"ru"` | Target language code |
-| `provider` | string | `"google"` | Translation provider |
+| `provider` | string | `"google"` | Translation provider: `"google"`, `"deepl"` |
 | `display` | string | `"float"` | Display mode: `"float"` or `"picker"` |
 | `picker` | string | `"auto"` | Picker: `"auto"`, `"telescope"`, `"fzf"`, `"snacks"`, `"mini"` |
+| `deepl.api_key` | string | `nil` | DeepL API key (or use `DEEPL_API_KEY` env) |
+| `deepl.pro` | boolean | `nil` | Force Pro/Free endpoint (`nil` = auto-detect by key) |
+| `deepl.formality` | string | `"default"` | Formality: `"default"`, `"more"`, `"less"`, `"prefer_more"`, `"prefer_less"` |
 
 ### Language Codes
 
@@ -158,10 +168,40 @@ require("babel").setup({
 | Provider | Status | API Key | Notes |
 |----------|:------:|:-------:|-------|
 | Google Translate | ✅ | No | Default, unofficial API |
-| [DeepL](https://deepl.com) | 🔜 | Yes (free tier) | Best quality, 500k chars/month free |
+| [DeepL](https://deepl.com) | 🧪 | Yes (free tier) | Best quality, 500k chars/month free |
 | [LibreTranslate](https://libretranslate.com) | 🔜 | No | Open source, self-hostable |
 | [Yandex](https://translate.yandex.ru) | 🔜 | Yes | Great for Russian |
 | [Lingva](https://lingva.ml) | 🔜 | No | Google proxy, no rate limits |
+
+> **🧪 Testing:** DeepL provider is implemented but needs testing. If you have a DeepL API key and want to help test, please [open an issue](https://github.com/acidsugarx/babel.nvim/issues) with your feedback!
+
+<details>
+<summary>DeepL Setup</summary>
+
+1. Get a free API key at [deepl.com/pro#developer](https://www.deepl.com/pro#developer) (500k chars/month free)
+
+2. Set up the API key (choose one):
+
+   **Option A:** Environment variable
+   ```bash
+   export DEEPL_API_KEY="your-api-key-here"
+   ```
+
+   **Option B:** In config
+   ```lua
+   require("babel").setup({
+     provider = "deepl",
+     deepl = {
+       api_key = "your-api-key-here",
+     },
+   })
+   ```
+
+3. The endpoint (Free/Pro) is auto-detected from the key suffix (`:fx` = Free). You can override with `deepl.pro = true/false`.
+
+4. If no API key is found, babel.nvim will automatically fall back to Google Translate with a warning.
+
+</details>
 
 ## 🤝 Contributing
 

--- a/lua/babel/config.lua
+++ b/lua/babel/config.lua
@@ -6,10 +6,16 @@
 ---@field options BabelOptions Current settings (after setup)
 ---@field setup fun(opts?: BabelOptions) Initialization function
 
+---@class BabelDeeplOptions Deepl provider settings
+---@field api_key? string API key (overrides DEEPL_API_KEY env)
+---@field pro? boolean Force Pro endpoint (auto-detect by default)
+---@field formality? "default"|"more"|"less"|"prefer_more"|"prefer_less"
+
 ---@class BabelOptions Plugin settings
+---@field deepl? BabelDeeplOptions
 ---@field source string Source language ('auto' = auto-detect)
 ---@field target string Target language ('ru', 'en', etc.)
----@field provider string Translation provider ('google', 'yandex')
+---@field provider string Translation provider ('google', 'deepl')
 ---@field display "float"|"picker" Display mode ('float' = floating window, 'picker' = use picker)
 ---@field picker "auto"|"telescope"|"fzf"|"snacks"|"mini" Picker to use (when display = "picker")
 ---@field float BabelFloatOptions Floating window options
@@ -44,6 +50,11 @@ local defaults = {
   keymaps = {
     translate = "<leader>tr",
     translate_word = "<leader>tw",
+  },
+  deepl = {
+    api_key = nil, -- use DEEPL_API_KEY env
+    pro = nil, -- auto-detect by key suffix
+    formality = "default",
   },
 }
 

--- a/lua/babel/providers/deepl.lua
+++ b/lua/babel/providers/deepl.lua
@@ -1,0 +1,106 @@
+local M = {}
+
+local config = require("babel.config")
+
+--- Gets api key from config/env
+local function get_api_key()
+  local key = config.options.deepl and config.options.deepl.api_key
+  if key then
+    return key
+  end
+  return os.getenv("DEEPL_API_KEY")
+end
+
+local function get_endpoint(api_key)
+  local deepl_opts = config.options.deepl or {}
+
+  if deepl_opts.pro == true then
+    return "https://api.deepl.com/v2/translate"
+  elseif deepl_opts.pro == false then
+    return "https://api-free.deepl.com/v2/translate"
+  end
+
+  if not api_key then
+    return "https://api-free.deepl.com/v2/translate"
+  end
+
+  if api_key:match(":fx$") then
+    return "https://api-free.deepl.com/v2/translate"
+  else
+    return "https://api.deepl.com/v2/translate"
+  end
+end
+
+local function map_source_lang(source)
+  if not source then
+    return nil
+  end
+
+  if source == "auto" then
+    return nil
+  else
+    return source:upper()
+  end
+end
+
+---Translate text using Deepl
+---@param text string Text to translate
+---@param source string Source language code
+---@param target string Target language code
+---@param callback fun(result: string) Callback with translated text
+function M.translate(text, source, target, callback)
+  local api_key = get_api_key()
+  local endpoint = get_endpoint(api_key)
+
+  if not api_key then
+    callback(nil, "DeepL API key not found")
+    return
+  end
+
+  local body = {
+    text = { text },
+    target_lang = target:upper(),
+    source_lang = map_source_lang(source),
+    formality = (config.options.deepl or {}).formality,
+  }
+
+  local cmd = {
+    "curl",
+    "-s",
+    "-X",
+    "POST",
+    "-H",
+    "Authorization: DeepL-Auth-Key " .. api_key,
+    "-H",
+    "Content-Type: application/json",
+    "-d",
+    vim.json.encode(body),
+    endpoint,
+  }
+
+  vim.fn.jobstart(cmd, {
+    stdout_buffered = true,
+    on_stdout = function(_, data)
+      local response = table.concat(data, "")
+
+      if response == "" then
+        callback(nil, "Empty response")
+        return
+      end
+      local ok, json = pcall(vim.json.decode, response)
+      if not ok then
+        callback(nil, "JSON parse error")
+        return
+      end
+
+      local translated = ""
+
+      if json.translations and json.translations[1] then
+        translated = json.translations[1].text
+      end
+      callback(translated, nil)
+    end,
+  })
+end
+
+return M

--- a/lua/babel/translate.lua
+++ b/lua/babel/translate.lua
@@ -6,6 +6,7 @@ local ui = require("babel.ui")
 -- Provider registry
 local providers = {
   google = require("babel.providers.google"),
+  deepl = require("babel.providers.deepl"),
 }
 
 ---Get providers by name
@@ -32,10 +33,20 @@ function M.translate(text)
 
   provider.translate(text, opts.source, opts.target, function(result, err)
     if err then
+      if opts.provider == "deepl" and err:match("API key") then
+        vim.notify("Babel: DeepL API key not found, falling back to Google", vim.log.levels.WARN)
+        providers.google.translate(text, opts.source, opts.target, function(r, e)
+          if e then
+            vim.notify("Babel: " .. e, vim.log.levels.ERROR)
+            return
+          end
+          ui.show(r, text)
+        end)
+        return
+      end
       vim.notify("Babel: " .. err, vim.log.levels.ERROR)
       return
     end
-    -- Pass both translated and original text to UI
     ui.show(result, text)
   end)
 end


### PR DESCRIPTION

## Add DeepL translation provider with automatic fallback to Google Translate when API key is missing

## Description

- **DeepL provider** (`lua/babel/providers/deepl.lua`) — full implementation with:
  - API key support via config (`deepl.api_key`) or environment variable (`DEEPL_API_KEY`)
  - Auto-detect Free/Pro endpoint by key suffix (`:fx` = Free)
  - Formality option (`default`, `more`, `less`, `prefer_more`, `prefer_less`)
- **Fallback logic** — automatically falls back to Google Translate with a warning if DeepL API key is not found
- **Config updates** — added `BabelDeeplOptions` type and defaults
- **README** — added DeepL configuration docs and setup guide
- **CHANGELOG** — documented new features

## Related Issue

Fixes #2 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [ ] I have tested my changes locally
- [x] I have updated the documentation (if applicable)
- [x] I have added entries to CHANGELOG.md under `[Unreleased]`
- [x] My code follows the project's style (run `make chores`)
